### PR TITLE
Updated CharacterWalletJournal model

### DIFF
--- a/EVEStandard/Models/CharacterWalletJournal.cs
+++ b/EVEStandard/Models/CharacterWalletJournal.cs
@@ -30,7 +30,7 @@ namespace EVEStandard.Models
         /// The context identifier.
         /// </value>
         [JsonProperty("context_id")]
-        public int ContextId { get; set; }
+        public long ContextId { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the context identifier.


### PR DESCRIPTION
Changed datatype for the context_id property to a long instead of int32 to prevent deserialisation errors.