### PR TITLE
Adjust route for Corporation Bookmarks

### DIFF
--- a/EVEStandard/API/Bookmarks.cs
+++ b/EVEStandard/API/Bookmarks.cs
@@ -85,7 +85,7 @@ namespace EVEStandard.API
                 { "page", page.ToString() }
             };
 
-            var responseModel = await GetAsync($"/v1/corporation/{corporationId}/bookmarks/", auth, ifNoneMatch, queryParameters);
+            var responseModel = await GetAsync($"/v1/corporations/{corporationId}/bookmarks/", auth, ifNoneMatch, queryParameters);
 
             CheckResponse(nameof(ListCorporationBookmarksV1Async), responseModel.Error, responseModel.Message, responseModel.LegacyWarning, logger);
 
@@ -110,7 +110,7 @@ namespace EVEStandard.API
                 { "page", page.ToString() }
             };
 
-            var responseModel = await GetAsync($"/v1/corporation/{corporationId}/bookmarks/folders/", auth, ifNoneMatch, queryParameters);
+            var responseModel = await GetAsync($"/v1/corporations/{corporationId}/bookmarks/folders/", auth, ifNoneMatch, queryParameters);
 
             CheckResponse(nameof(ListCorporationBookmarkFoldersV1Async), responseModel.Error, responseModel.Message, responseModel.LegacyWarning, logger);
 


### PR DESCRIPTION
Looks like they either changed it or there was a type on the corporation bookmark retrieval route.