### PR TITLE
Update type for contract item

### DIFF
--- a/EVEStandard/Models/ContractItem.cs
+++ b/EVEStandard/Models/ContractItem.cs
@@ -39,7 +39,7 @@ namespace EVEStandard.Models
         /// </summary>
         /// <value>Unique ID for the item</value>
         [JsonProperty("record_id")]
-        public long RecordId { get; set; }
+        public int RecordId { get; set; }
 
         /// <summary>
         /// Type ID for item


### PR DESCRIPTION
Closes #83 

I've gone through and checked contract id as a parameter and as part of a return DTO. Everything is treated as an int.