### PR TITLE
Add System.Obsolete attribute to the Bookmarks class.

### DIFF
--- a/EVEStandard/API/Bookmarks.cs
+++ b/EVEStandard/API/Bookmarks.cs
@@ -11,6 +11,7 @@ namespace EVEStandard.API
     /// Bookmarks API
     /// </summary>
     /// <seealso cref="EVEStandard.API.APIBase" />
+    [System.Obsolete("Bookmark endpoints are currently not working correctly due to recent changes to the bookmark system. Use of this endpoint may return unexpected results.")]
     public class Bookmarks : APIBase
     {
         private readonly ILogger logger = LibraryLogging.CreateLogger<Bookmarks>();


### PR DESCRIPTION
Along with the recent release of Shareable Bookmarks, bookmark endpoints now return empty lists as results. Currently, there is no way to know from use of the library that the bookmark endpoints are returning incorrect data.

Adding the System.Obsolete attribute to the class will produce a compiler warning advising the developer against using bookmark endpoints. It will also cross out the class when using IntelliSense, notifying the user that something is awry. 

See section 8 of this article that describes these changes to the endpoints. https://www.eveonline.com/article/q1dsd0/shareable-bookmarks-alliance-bookmarks-and-more