### PR TITLE
Convert MarketOrder's Range using custom converter to save memory and performance

### DIFF
--- a/EVEStandard.Tests/Models/MarketOrderTests.cs
+++ b/EVEStandard.Tests/Models/MarketOrderTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EVEStandard.Models;
+using Xunit;
+
+namespace EVEStandard.Tests.Models;
+
+/// <summary>
+/// Deserialization test for MarketOrder to verify correctness with the JsonConverter.
+/// </summary>
+public class MarketOrderTests
+{
+    [Fact]
+    public void BasicSingleMarketOrder()
+    {
+        var json = """
+                   {
+                       "duration": 90,
+                       "is_buy_order": false,
+                       "issued": "2026-04-26T17:35:29Z",
+                       "location_id": 60003760,
+                       "min_volume": 1,
+                       "order_id": 7283408898,
+                       "price": 37080000,
+                       "range": "region",
+                       "system_id": 30000142,
+                       "type_id": 45624,
+                       "volume_remain": 4,
+                       "volume_total": 24
+                     }
+                   """;
+        var order = JsonSerializer.Deserialize<MarketOrder>(json);
+
+        Assert.NotNull(order);
+        Assert.Equal(7283408898, order.OrderId);
+        Assert.Equal("region", order.Range);
+        Assert.Equal(45624, order.TypeId);
+    }
+
+    [Fact]
+    public void BasicListMarketOrder()
+    {
+        var json = """
+                   [
+                   {
+                     "duration": 90,
+                     "is_buy_order": false,
+                     "issued": "2026-04-26T17:35:29Z",
+                     "location_id": 60003760,
+                     "min_volume": 1,
+                     "order_id": 7283408898,
+                     "price": 37080000,
+                     "range": "region",
+                     "system_id": 30000142,
+                     "type_id": 45624,
+                     "volume_remain": 4,
+                     "volume_total": 24
+                   },
+                   {
+                     "duration": 90,
+                     "is_buy_order": false,
+                     "issued": "2026-07-21T19:01:04Z",
+                     "location_id": 60003760,
+                     "min_volume": 1,
+                     "order_id": 7383023619,
+                     "price": 35990000,
+                     "range": "40",
+                     "system_id": 30000142,
+                     "type_id": 17217,
+                     "volume_remain": 2,
+                     "volume_total": 2
+                   }
+                   ]
+                   """;
+
+        var orders = JsonSerializer.Deserialize<List<MarketOrder>>(json);
+        Assert.NotNull(orders);
+        Assert.Equal(2, orders.Count);
+        Assert.Equal("region", orders[0].Range);
+        Assert.Equal("40", orders[1].Range);
+    }
+
+    [Fact]
+    public void VerifyUnknownRangeStillReads()
+    {
+        var json = """
+                   {
+                       "duration": 90,
+                       "is_buy_order": false,
+                       "issued": "2026-04-26T17:35:29Z",
+                       "location_id": 60003760,
+                       "min_volume": 1,
+                       "order_id": 7283408898,
+                       "price": 37080000,
+                       "range": "unknown",
+                       "system_id": 30000142,
+                       "type_id": 45624,
+                       "volume_remain": 4,
+                       "volume_total": 24
+                     }
+                   """;
+        var order = JsonSerializer.Deserialize<MarketOrder>(json);
+
+        Assert.NotNull(order);
+        Assert.Equal(7283408898, order.OrderId);
+        Assert.Equal("unknown", order.Range);
+        Assert.Equal(45624, order.TypeId);
+    }
+}

--- a/EVEStandard/EVEStandard.csproj
+++ b/EVEStandard/EVEStandard.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 

--- a/EVEStandard/Models/MarketOrder.cs
+++ b/EVEStandard/Models/MarketOrder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace EVEStandard.Models
@@ -61,6 +63,7 @@ namespace EVEStandard.Models
         /// </summary>
         /// <value>range string</value>
         [JsonPropertyName("range")]
+        [JsonConverter(typeof(EveRangeStringConverter))]
         public string Range { get; set; }
 
         /// <summary>
@@ -94,5 +97,59 @@ namespace EVEStandard.Models
         public long VolumeTotal { get; set; }
 
         #endregion Properties
+
+        #region JSON Converters
+
+        /**
+         * Converts the range strings using Spans.
+         * <br/>
+         * Why? It is about 10% faster compared to the base method, and as string literals are interned by default, it
+         * also reduces the memory usage of the MarketOrder objects in memory.
+         */
+        public class EveRangeStringConverter : JsonConverter<string>
+        {
+            // Note: ValueTextEquals accepts a ReadonlySpan<T> as parameter, strings are not directly convertable to this,
+            // as a result, we need to convert them manually down to byte[] which will implicitly convert to Span during
+            // use.
+            // Currently, the project uses C#8, but with C#11 we could remove these and use u8 literals in the Read function,
+            // such as <code>if (reader.ValueTextEquals("station"u8)) return "station";</code>.
+            private static readonly byte[] StationUtf8 = Encoding.UTF8.GetBytes("station");
+            private static readonly byte[] RegionUtf8 = Encoding.UTF8.GetBytes("region");
+            private static readonly byte[] SolarSystemUtf8 = Encoding.UTF8.GetBytes("solarsystem");
+            private static readonly byte[] Range1Utf8 = Encoding.UTF8.GetBytes("1");
+            private static readonly byte[] Range2Utf8 = Encoding.UTF8.GetBytes("2");
+            private static readonly byte[] Range3Utf8 = Encoding.UTF8.GetBytes("3");
+            private static readonly byte[] Range4Utf8 = Encoding.UTF8.GetBytes("4");
+            private static readonly byte[] Range5Utf8 = Encoding.UTF8.GetBytes("5");
+            private static readonly byte[] Range10Utf8 = Encoding.UTF8.GetBytes("10");
+            private static readonly byte[] Range20Utf8 = Encoding.UTF8.GetBytes("20");
+            private static readonly byte[] Range30Utf8 = Encoding.UTF8.GetBytes("30");
+            private static readonly byte[] Range40Utf8 = Encoding.UTF8.GetBytes("40");
+
+            public override string Read(ref Utf8JsonReader reader, global::System.Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.ValueTextEquals(StationUtf8)) return "station";
+                if (reader.ValueTextEquals(RegionUtf8)) return "region";
+                if (reader.ValueTextEquals(SolarSystemUtf8)) return "solarsystem";
+                if (reader.ValueTextEquals(Range1Utf8)) return "1";
+                if (reader.ValueTextEquals(Range2Utf8)) return "2";
+                if (reader.ValueTextEquals(Range3Utf8)) return "3";
+                if (reader.ValueTextEquals(Range4Utf8)) return "4";
+                if (reader.ValueTextEquals(Range5Utf8)) return "5";
+                if (reader.ValueTextEquals(Range10Utf8)) return "10";
+                if (reader.ValueTextEquals(Range20Utf8)) return "20";
+                if (reader.ValueTextEquals(Range30Utf8)) return "30";
+                if (reader.ValueTextEquals(Range40Utf8)) return "40";
+
+                return reader.GetString();
+            }
+
+            public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value);
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Hello!

As discussed over at Discord, this change brings some improvements towards parsing the MarketOrder objects from ESI. Currently every single Range string has to be allocated, and stored. This generates about 20-30mb of duplicated strings on the heap if you gather all the orders (there are about 1.5-1.6m active orders). This change reduces the allocations as by design string literals are interned, but parsing has to be done manually.

Tiny difference from what I posted over at Discord is that you cannot use u8 literals with C#8 so had to manually convert the strings which looks a bit ugly. Performance-wise it is the same.

An additional package was added to the project (`System.Memory`), as `Span<T>` is only in the core library since stadard2.1. The addition of this library is a no-op in its current state as `System.Text.Json` already pulled it in, but added it in case they eventually drop it.

Benchmark:
| Method            | Mean     | Error   | StdDev  | Gen0       | Gen1       | Gen2      | Allocated |
|------------------ |---------:|--------:|--------:|-----------:|-----------:|----------:|----------:|
| LoadStandard      | 947.3 ms | 9.52 ms | 7.95 ms | 17000.0000 | 16000.0000 | 3000.0000 | 631.49 MB |
| LoadSpan          | 876.8 ms | 6.27 ms | 5.56 ms | 12000.0000 | 11000.0000 | 2000.0000 | 571.34 MB |
| LoadSpanCs8 | 878.1 ms | 7.29 ms | 5.69 ms | 12000.0000 | 11000.0000 | 2000.0000 | 571.35 MB |

Standard is the original class, Span is with converter using u8 literals, SpanCs8 is this version. Speed increase is about 8%, and with the benefit of a bit less GC activity and about 10-15% less raw memory usage (dependent on which range string was allocated).

Also added 3 test cases to verify the converter is parsing properly.